### PR TITLE
docs: 修复文件后缀名错误

### DIFF
--- a/docs/basic/redux-test/README.md
+++ b/docs/basic/redux-test/README.md
@@ -417,7 +417,7 @@ describe("reducer", () => {
 下面我们来实现这个功能的集成测试吧。首先，我们来改造一下 `React Tesitng Library` 提供的 `render` 函数：
 
 ```tsx
-// tests/testUtils/render.ts
+// tests/testUtils/render.tsx
 import React, { FC } from "react";
 import { render as rtlRender, RenderOptions } from "@testing-library/react";
 import { configureStore } from "@reduxjs/toolkit";


### PR DESCRIPTION
一步步跟着作者的教程走过来，这里发现个错误，跟着这个注释创建文件 `tests/testUtils/render.ts` ，发现问题：
![D{_6~KY`UV B~ZM`~8{PBT1](https://user-images.githubusercontent.com/25282180/170293456-7634d15d-45f5-4815-ae1f-6d7c84c37b9b.png)

google 了一下相似的问题：

https://stackoverflow.com/questions/62059408/reactjs-and-typescript-refers-to-a-value-but-is-being-used-as-a-type-here-ts

![image](https://user-images.githubusercontent.com/25282180/170293645-200d123b-2e7f-48e4-8c22-9231cc52e167.png)

然后核对作者的仓库，确实是 `.tsx` 文件，而不是 `.ts` 文件

![image](https://user-images.githubusercontent.com/25282180/170293886-bbf8177d-4937-48a7-b9d1-c56d06cf6788.png)

