### PR TITLE
fix: modify file suffix

### DIFF
--- a/docs/basic/component-test/README.md
+++ b/docs/basic/component-test/README.md
@@ -81,10 +81,10 @@ const AuthButton: FC<Props> = (props) => {
 export default AuthButton;
 ```
 
-这里我们还不忘搞点花里胡哨，引入了 `src/components/AuthButton/styles.less`：
+这里我们还不忘搞点花里胡哨，引入了 `src/components/AuthButton/styles.module.less`：
 
 ```less
-// src/components/AuthButton/styles.less
+// src/components/AuthButton/styles.module.less
 .authButton {
   border: 1px solid red;
 }


### PR DESCRIPTION
less 文件名错误，应该为 `styles.module.less`，不然 执行 `yarn start` 时 `webpack` 启动会报错

![image](https://user-images.githubusercontent.com/25282180/170466313-318f4323-e733-4586-9d8d-0e8e36a97714.png)

这里的引入是带有 `module` 的，上文没有

![image](https://user-images.githubusercontent.com/25282180/170464900-bfd8c291-c8ff-4ff8-ae61-94aad11280ef.png)

![image](https://user-images.githubusercontent.com/25282180/170464940-ece8e29e-1aa3-446f-8d58-1eb6032a71ca.png)
