### PR TITLE
docs(test-environment): 修复Object.defineProperty在vitest报Cannot redefine property: localStorage的错误问题

### DIFF
--- a/docs/basic/test-environment/README.md
+++ b/docs/basic/test-environment/README.md
@@ -75,7 +75,8 @@ Object.defineProperty(global, 'localStorage', {
     clear() {
       this.store = {}
     }
-  }
+  },
+  configurable: true,
 })
 ```
 


### PR DESCRIPTION
看到教程的[全局mock](http://github.yanhaixiang.com/jest-tutorial/basic/test-environment/#%E5%85%A8%E5%B1%80-mock)
在vitest出现报错
![image](https://user-images.githubusercontent.com/20942781/170852623-d3839915-ea4f-4c13-a908-a85882f047ca.png)
在Object.defineProperty添加configurable: true,解决问题