### PR TITLE
chore: bump webpack-cli from 4.9.2 to 4.10.0

### DIFF
--- a/docs/basic/config-react/README.md
+++ b/docs/basic/config-react/README.md
@@ -17,7 +17,7 @@
 
 ```shell
 # Webpack 依赖
-npm i -D webpack@5.72.0 webpack-cli@4.9.2 webpack-dev-server@4.8.1 html-webpack-plugin@5.5.0
+npm i -D webpack@5.72.0 webpack-cli@4.10.0 webpack-dev-server@4.8.1 html-webpack-plugin@5.5.0
 
 # Loader
 npm i -D less@4.1.2 less-loader@10.2.0 style-loader@3.3.1 css-loader@6.7.1 ts-loader@9.2.8
@@ -192,12 +192,5 @@ export default App;
 ## 启动应用
 
 现在执行 `npm run start`，进入 `localhost:3000` 就能看到我们的页面了：
-
-::: warning
-如果你出现了 `[webpack-cli] TypeError: cli.isMultipleCompiler is not a function` 报错，
-这是因为 `webpack-cli@4.9` 和 `webpack-cli/serve@1.7` 有冲突导致的，[详见这个 Issue](https://github.com/haixiangyan/jest-tutorial-example) 。
-
-解决方法是在 `package-lock.json` 里找到 `node_modules/@webpack-cli/serve` 配置项，把里面的 `"version": "1.7.0"` 改成 `"version": "1.6.1"` 即可。
-:::
 
 ![](./react-preview.png)


### PR DESCRIPTION
Hi 海怪大佬,

我在阅读你的《Jest 实践指南》[引入React 纯配置](https://github.yanhaixiang.com/jest-tutorial/basic/config-react/)章节时，发现根据你的配置并不能成功。

根据你文末的提示，我检查了该[issue](https://github.com/vaadin/flow/issues/13952#issuecomment-1153616803)。除了降`node_modules/@webpack-cli/serve`版本外，直接将`webpack-cli` 从 `v4.9.2` 升级到 `v4.10.0`也可以解决该问题，且更加清晰。这样是否更加合理呢？

最后再次感谢大佬的Jest分享～